### PR TITLE
added guard clause for invalid city name

### DIFF
--- a/src/Component/Weather/Weather.js
+++ b/src/Component/Weather/Weather.js
@@ -181,6 +181,7 @@ function minMaxTempsByWeek(weeklyTemps) {
 
 // Functional component starts here
 function Weather() {
+  const [error, setError] = useState();
   const [inputField, setinputField] = useState("");
   const [city, setCity] = useState("London");
   const [currentWeather, setCurrentWeather] = useState({
@@ -243,239 +244,252 @@ function Weather() {
 
   useEffect(() => {
     async function getData() {
-      // const res = await fetch(
-      //   `https://api.openweathermap.org/data/2.5/forecast?q=${city}&units=metric&appid=1a1a53ffdffb4a6940e1c179d178a70a`
-      // );
-      // const data = await res.json();
+      try {
+        const res = await fetch(
+          `https://api.openweathermap.org/data/2.5/forecast?q=${city}&units=metric&appid=1a1a53ffdffb4a6940e1c179d178a70a`
+        );
+        const data = await res.json();
 
-      // // converts date from API to corresponding day of the week
-      // const listWithDay = data.list.map((object) => {
-      //   const date = new Date(`${object.dt_txt}`);
-      //   const day = days[`${date.getDay()}`];
-      //   return { ...object, day: day };
-      // });
+        // converts date from API to corresponding day of the week
+        const listWithDay = data.list.map((object) => {
+          const date = new Date(`${object.dt_txt}`);
+          const day = days[`${date.getDay()}`];
+          return { ...object, day: day };
+        });
 
-      // const UNIXSunriseSunset = {
-      //   sunrise: data.city.sunrise,
-      //   sunset: data.city.sunset,
-      // };
-
-      // // offset due to british summer time/weird interaction with API
-      // const summertimeOffset = 3600;
-
-      // const actualSunriseSunset = {
-      //   sunrise:
-      //     UNIXSunriseSunset.sunrise + data.city.timezone - summertimeOffset,
-      //   sunset:
-      //     UNIXSunriseSunset.sunset + data.city.timezone - summertimeOffset,
-      // };
-
-      // const convertSunriseSunset = {
-      //   sunrise: unixToHoursMins(actualSunriseSunset.sunrise),
-      //   sunset: unixToHoursMins(actualSunriseSunset.sunset),
-      // };
-
-      // // gives data in the format for our use case
-      // const formattedData = {
-      //   ...data,
-      //   list: listWithDay,
-      //   city: {
-      //     sunrise: convertSunriseSunset.sunrise,
-      //     sunset: convertSunriseSunset.sunset,
-      //   },
-      // };
-      // console.log("%c Formatted Data:", "color: red", formattedData);
-
-      // converts date from API to corresponding day of the week
-      const listWithDay = mockData.list.map((object) => {
-        const date = new Date(`${object.dt_txt}`);
-        const day = days[`${date.getDay()}`];
-        return { ...object, day: day };
-      });
-
-      const UNIXSunriseSunset = {
-        sunrise: mockData.city.sunrise,
-        sunset: mockData.city.sunset,
-      };
-
-      // offset due to british summer time/weird interaction with API
-      const summertimeOffset = 3600;
-
-      const actualSunriseSunset = {
-        sunrise:
-          UNIXSunriseSunset.sunrise + mockData.city.timezone - summertimeOffset,
-        sunset:
-          UNIXSunriseSunset.sunset + mockData.city.timezone - summertimeOffset,
-      };
-
-      const convertSunriseSunset = {
-        sunrise: unixToHoursMins(actualSunriseSunset.sunrise),
-        sunset: unixToHoursMins(actualSunriseSunset.sunset),
-      };
-
-      // gives data in the format for our use case
-      const formattedData = {
-        ...mockData,
-        list: listWithDay,
-        city: {
-          sunrise: convertSunriseSunset.sunrise,
-          sunset: convertSunriseSunset.sunset,
-        },
-      };
-      console.log("%c Formatted Data:", "color: red", formattedData);
-
-      const dailyData = filterDataByDay(formattedData.list);
-      console.log("daily: ", dailyData);
-
-      // extracts all necessary TEMPERATURE data from the data returned from the API
-      const weeklyTemps = getWeeklyTemps(dailyData);
-      console.log("weekly temps:", weeklyTemps);
-
-      let minMaxTemps = minMaxTempsByWeek(weeklyTemps);
-      console.log("minMaxTemps: ", minMaxTemps);
-
-      // extracts all necessary HUMIDITY data from the data returned from the API
-      const weeklyHumidity = getWeeklyHumidity(dailyData);
-      console.log("weekly humidity:", weeklyHumidity);
-
-      const avgWeeklyHumidity = getAvgWeeklyHumidity(weeklyHumidity);
-      console.log("avgWeeklyHumidity:", avgWeeklyHumidity);
-
-      // extracts all necessary WIND data from the data returned from the API
-      const weeklyWindSpeed = getWeeklyWindSpeed(dailyData);
-      console.log("weekly wind speed:", weeklyWindSpeed);
-
-      const avgWeeklyWindSpeed = getAvgWeeklyWindSpeed(weeklyWindSpeed);
-      console.log("avgWeeklyWindSpeed:", avgWeeklyWindSpeed);
-
-      setCurrentWeather((currentWeather) => {
-        return {
-          ...currentWeather,
-          temp: Math.round(formattedData.list[0].main.temp),
-          icon: formattedData.list[0].weather[0].icon,
-          day: formattedData.list[0].day,
+        const UNIXSunriseSunset = {
+          sunrise: data.city.sunrise,
+          sunset: data.city.sunset,
         };
-      });
 
-      setTemp((temp) => {
-        return {
-          ...temp,
-          sunday:
-            minMaxTemps.sunday === null
-              ? null
-              : { max: minMaxTemps.sunday.max, min: minMaxTemps.sunday.min },
-          monday:
-            minMaxTemps.monday === null
-              ? null
-              : { max: minMaxTemps.monday.max, min: minMaxTemps.monday.min },
-          tuesday:
-            minMaxTemps.tuesday === null
-              ? null
-              : {
-                  max: minMaxTemps.tuesday.max,
-                  min: minMaxTemps.tuesday.min,
-                },
-          wednesday:
-            minMaxTemps.wednesday === null
-              ? null
-              : {
-                  max: minMaxTemps.wednesday.max,
-                  min: minMaxTemps.wednesday.min,
-                },
-          thursday:
-            minMaxTemps.thursday === null
-              ? null
-              : {
-                  max: minMaxTemps.thursday.max,
-                  min: minMaxTemps.thursday.min,
-                },
-          friday:
-            minMaxTemps.friday === null
-              ? null
-              : { max: minMaxTemps.friday.max, min: minMaxTemps.friday.min },
-          saturday:
-            minMaxTemps.saturday === null
-              ? null
-              : {
-                  max: minMaxTemps.saturday.max,
-                  min: minMaxTemps.saturday.min,
-                },
-        };
-      });
-      console.log("Temp updated:", temp);
+        // offset due to british summer time/weird interaction with API
+        const summertimeOffset = 3600;
 
-      setHumidity((humidity) => {
-        return {
-          ...humidity,
-          sunday:
-            avgWeeklyHumidity.sunday === null ? null : avgWeeklyHumidity.sunday,
-          monday:
-            avgWeeklyHumidity.monday === null ? null : avgWeeklyHumidity.monday,
-          tuesday:
-            avgWeeklyHumidity.tuesday === null
-              ? null
-              : avgWeeklyHumidity.tuesday,
-          wednesday:
-            avgWeeklyHumidity.wednesday === null
-              ? null
-              : avgWeeklyHumidity.wednesday,
-          thursday:
-            avgWeeklyHumidity.thursday === null
-              ? null
-              : avgWeeklyHumidity.thursday,
-          friday:
-            avgWeeklyHumidity.friday === null ? null : avgWeeklyHumidity.friday,
-          saturday:
-            avgWeeklyHumidity.saturday === null
-              ? null
-              : avgWeeklyHumidity.saturday,
+        const actualSunriseSunset = {
+          sunrise:
+            UNIXSunriseSunset.sunrise + data.city.timezone - summertimeOffset,
+          sunset:
+            UNIXSunriseSunset.sunset + data.city.timezone - summertimeOffset,
         };
-      });
-      console.log("humidity updated:", humidity);
 
-      setWind((wind) => {
-        return {
-          ...wind,
-          sunday:
-            avgWeeklyWindSpeed.sunday === null
-              ? null
-              : avgWeeklyWindSpeed.sunday,
-          monday:
-            avgWeeklyWindSpeed.monday === null
-              ? null
-              : avgWeeklyWindSpeed.monday,
-          tuesday:
-            avgWeeklyWindSpeed.tuesday === null
-              ? null
-              : avgWeeklyWindSpeed.tuesday,
-          wednesday:
-            avgWeeklyWindSpeed.wednesday === null
-              ? null
-              : avgWeeklyWindSpeed.wednesday,
-          thursday:
-            avgWeeklyWindSpeed.thursday === null
-              ? null
-              : avgWeeklyWindSpeed.thursday,
-          friday:
-            avgWeeklyWindSpeed.friday === null
-              ? null
-              : avgWeeklyWindSpeed.friday,
-          saturday:
-            avgWeeklyWindSpeed.saturday === null
-              ? null
-              : avgWeeklyWindSpeed.saturday,
+        const convertSunriseSunset = {
+          sunrise: unixToHoursMins(actualSunriseSunset.sunrise),
+          sunset: unixToHoursMins(actualSunriseSunset.sunset),
         };
-      });
-      console.log("wind updated:", wind);
 
-      setSun((sun) => {
-        return {
-          ...sun,
-          sunrise: formattedData.city.sunrise,
-          sunset: formattedData.city.sunset,
+        // gives data in the format for our use case
+        const formattedData = {
+          ...data,
+          list: listWithDay,
+          city: {
+            sunrise: convertSunriseSunset.sunrise,
+            sunset: convertSunriseSunset.sunset,
+          },
         };
-      });
-      console.log("sun updated:", sun);
+        console.log("%c Formatted Data:", "color: red", formattedData);
+
+        // // converts date from API to corresponding day of the week
+        // const listWithDay = mockData.list.map((object) => {
+        //   const date = new Date(`${object.dt_txt}`);
+        //   const day = days[`${date.getDay()}`];
+        //   return { ...object, day: day };
+        // });
+
+        // const UNIXSunriseSunset = {
+        //   sunrise: mockData.city.sunrise,
+        //   sunset: mockData.city.sunset,
+        // };
+
+        // // offset due to british summer time/weird interaction with API
+        // const summertimeOffset = 3600;
+
+        // const actualSunriseSunset = {
+        //   sunrise:
+        //     UNIXSunriseSunset.sunrise + mockData.city.timezone - summertimeOffset,
+        //   sunset:
+        //     UNIXSunriseSunset.sunset + mockData.city.timezone - summertimeOffset,
+        // };
+
+        // const convertSunriseSunset = {
+        //   sunrise: unixToHoursMins(actualSunriseSunset.sunrise),
+        //   sunset: unixToHoursMins(actualSunriseSunset.sunset),
+        // };
+
+        // // gives data in the format for our use case
+        // const formattedData = {
+        //   ...mockData,
+        //   list: listWithDay,
+        //   city: {
+        //     sunrise: convertSunriseSunset.sunrise,
+        //     sunset: convertSunriseSunset.sunset,
+        //   },
+        // };
+        // console.log("%c Formatted Data:", "color: red", formattedData);
+
+        const dailyData = filterDataByDay(formattedData.list);
+        console.log("daily: ", dailyData);
+
+        // extracts all necessary TEMPERATURE data from the data returned from the API
+        const weeklyTemps = getWeeklyTemps(dailyData);
+        console.log("weekly temps:", weeklyTemps);
+
+        let minMaxTemps = minMaxTempsByWeek(weeklyTemps);
+        console.log("minMaxTemps: ", minMaxTemps);
+
+        // extracts all necessary HUMIDITY data from the data returned from the API
+        const weeklyHumidity = getWeeklyHumidity(dailyData);
+        console.log("weekly humidity:", weeklyHumidity);
+
+        const avgWeeklyHumidity = getAvgWeeklyHumidity(weeklyHumidity);
+        console.log("avgWeeklyHumidity:", avgWeeklyHumidity);
+
+        // extracts all necessary WIND data from the data returned from the API
+        const weeklyWindSpeed = getWeeklyWindSpeed(dailyData);
+        console.log("weekly wind speed:", weeklyWindSpeed);
+
+        const avgWeeklyWindSpeed = getAvgWeeklyWindSpeed(weeklyWindSpeed);
+        console.log("avgWeeklyWindSpeed:", avgWeeklyWindSpeed);
+
+        setError("no error");
+
+        setCurrentWeather((currentWeather) => {
+          return {
+            ...currentWeather,
+            temp: Math.round(formattedData.list[0].main.temp),
+            icon: formattedData.list[0].weather[0].icon,
+            day: formattedData.list[0].day,
+          };
+        });
+
+        setTemp((temp) => {
+          return {
+            ...temp,
+            sunday:
+              minMaxTemps.sunday === null
+                ? null
+                : { max: minMaxTemps.sunday.max, min: minMaxTemps.sunday.min },
+            monday:
+              minMaxTemps.monday === null
+                ? null
+                : { max: minMaxTemps.monday.max, min: minMaxTemps.monday.min },
+            tuesday:
+              minMaxTemps.tuesday === null
+                ? null
+                : {
+                    max: minMaxTemps.tuesday.max,
+                    min: minMaxTemps.tuesday.min,
+                  },
+            wednesday:
+              minMaxTemps.wednesday === null
+                ? null
+                : {
+                    max: minMaxTemps.wednesday.max,
+                    min: minMaxTemps.wednesday.min,
+                  },
+            thursday:
+              minMaxTemps.thursday === null
+                ? null
+                : {
+                    max: minMaxTemps.thursday.max,
+                    min: minMaxTemps.thursday.min,
+                  },
+            friday:
+              minMaxTemps.friday === null
+                ? null
+                : { max: minMaxTemps.friday.max, min: minMaxTemps.friday.min },
+            saturday:
+              minMaxTemps.saturday === null
+                ? null
+                : {
+                    max: minMaxTemps.saturday.max,
+                    min: minMaxTemps.saturday.min,
+                  },
+          };
+        });
+        console.log("Temp updated:", temp);
+
+        setHumidity((humidity) => {
+          return {
+            ...humidity,
+            sunday:
+              avgWeeklyHumidity.sunday === null
+                ? null
+                : avgWeeklyHumidity.sunday,
+            monday:
+              avgWeeklyHumidity.monday === null
+                ? null
+                : avgWeeklyHumidity.monday,
+            tuesday:
+              avgWeeklyHumidity.tuesday === null
+                ? null
+                : avgWeeklyHumidity.tuesday,
+            wednesday:
+              avgWeeklyHumidity.wednesday === null
+                ? null
+                : avgWeeklyHumidity.wednesday,
+            thursday:
+              avgWeeklyHumidity.thursday === null
+                ? null
+                : avgWeeklyHumidity.thursday,
+            friday:
+              avgWeeklyHumidity.friday === null
+                ? null
+                : avgWeeklyHumidity.friday,
+            saturday:
+              avgWeeklyHumidity.saturday === null
+                ? null
+                : avgWeeklyHumidity.saturday,
+          };
+        });
+        console.log("humidity updated:", humidity);
+
+        setWind((wind) => {
+          return {
+            ...wind,
+            sunday:
+              avgWeeklyWindSpeed.sunday === null
+                ? null
+                : avgWeeklyWindSpeed.sunday,
+            monday:
+              avgWeeklyWindSpeed.monday === null
+                ? null
+                : avgWeeklyWindSpeed.monday,
+            tuesday:
+              avgWeeklyWindSpeed.tuesday === null
+                ? null
+                : avgWeeklyWindSpeed.tuesday,
+            wednesday:
+              avgWeeklyWindSpeed.wednesday === null
+                ? null
+                : avgWeeklyWindSpeed.wednesday,
+            thursday:
+              avgWeeklyWindSpeed.thursday === null
+                ? null
+                : avgWeeklyWindSpeed.thursday,
+            friday:
+              avgWeeklyWindSpeed.friday === null
+                ? null
+                : avgWeeklyWindSpeed.friday,
+            saturday:
+              avgWeeklyWindSpeed.saturday === null
+                ? null
+                : avgWeeklyWindSpeed.saturday,
+          };
+        });
+        console.log("wind updated:", wind);
+
+        setSun((sun) => {
+          return {
+            ...sun,
+            sunrise: formattedData.city.sunrise,
+            sunset: formattedData.city.sunset,
+          };
+        });
+        console.log("sun updated:", sun);
+      } catch (error) {
+        setError(error);
+        console.error(error);
+      }
     }
     getData();
   }, [city]);
@@ -510,9 +524,11 @@ function Weather() {
         />
         <div className="city-temp">
           <p className="current-temp">{`${currentWeather.temp}\u00B0`}</p>
-          <h3 className="city-name">{`${city
-            .charAt(0)
-            .toUpperCase()}${city.slice(1)}`}</h3>
+          <h3 className="city-name">{`${
+            error === "no error"
+              ? city.charAt(0).toUpperCase() + city.slice(1)
+              : ""
+          }`}</h3>
         </div>
       </div>
       <div className="Weather">


### PR DESCRIPTION
- Fixed bug where an invalid city name would show on the h3 element on the weather page. A guard clause/conditional rendering was added to make the h3 element empty when an invalid city name was entered into the input field.